### PR TITLE
Be able to replace sender name in every message

### DIFF
--- a/src/main/java/fr/xephi/authme/message/Messages.java
+++ b/src/main/java/fr/xephi/authme/message/Messages.java
@@ -18,6 +18,8 @@ public class Messages {
     // Custom Authme tag replaced to new line
     private static final String NEWLINE_TAG = "%nl%";
 
+    private static final String PLAYER_TAG = "%username%";
+
     /** Contains the keys of the singular messages for time units. */
     private static final Map<TimeUnit, MessageKey> TIME_UNIT_SINGULARS = ImmutableMap.<TimeUnit, MessageKey>builder()
         .put(TimeUnit.SECONDS, MessageKey.SECOND)
@@ -51,7 +53,7 @@ public class Messages {
     public void send(CommandSender sender, MessageKey key) {
         String[] lines = retrieve(key);
         for (String line : lines) {
-            sender.sendMessage(line);
+            sender.sendMessage(line.replace(PLAYER_TAG, sender.getName()));
         }
     }
 
@@ -65,7 +67,7 @@ public class Messages {
      * @param replacements The replacements to apply for the tags
      */
     public void send(CommandSender sender, MessageKey key, String... replacements) {
-        String message = retrieveSingle(key, replacements);
+        String message = retrieveSingle(key, replacements).replace(PLAYER_TAG, sender.getName());
         for (String line : message.split("\n")) {
             sender.sendMessage(line);
         }


### PR DESCRIPTION
By setting a unique Tag (%username%), we can replace it with the sender's name inside the Send function. 
This pull closes #829.

Some thoughts:
- It won't check for a Player instance, so even Console and Admin commands will replace it with the sender's name, if any. (I think Console gives an UUID or "ConsoleSender" as his name).
- Since Admin commands aren't yet translated, part of the above thought can be ignored for now.
- By setting it as a "special" tag, like %nl%, it is different than specific single message tags that only have 1 % at the beginning. This however may cause confusion, we should add a comment line inside every file stating which are the global replaceble tags and what they do.